### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM centos/python-36-centos7
+
+# Install requirements
+COPY requirements.txt /requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt
+
+# Copy over our codebase and export the app
+COPY . /aicoe-insights-clustering
+WORKDIR /aicoe-insights-clustering
+EXPOSE 8080
+CMD [ "python", "app.py" ]


### PR DESCRIPTION
For easier development it might be handy to be able to deploy locally in Docker. Here's a `Dockerfile` I use for quick deployment... This build is the same as in the OpenShift (Centos based)

Usage:
```
$ docker build . -t aicoe-insights-clustering --network=host
...

$ docker images
REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
clustering             latest              117a17806363        24 hours ago        994MB
...

$ cat env.list
FLASK_ENV=development
CEPH_KEY=...
CEPH_SECRET=...
CEPH_ENDPOINT=...

$ docker run --env-file env.list  -p 8080:8080 -it aicoe-insights-clustering

```